### PR TITLE
Script streamlining

### DIFF
--- a/infrastructure/scripts/sparsecheckout.sh
+++ b/infrastructure/scripts/sparsecheckout.sh
@@ -3,11 +3,13 @@
 # This script takes a list of directories to clone from 
 # the mslearn-aspnet-core repo. Since it's a subset of 
 # the repo, it's referred to as a "sparse checkout."
+# An environment variable named $gitBranch should be set
+# and contain the branch to be used, e.g., "live" or "master".
 
 # constants
 DIR="contoso-pets"
 REPOS="https://github.com/MicrosoftDocs/mslearn-aspnet-core"
-BRANCH="master"
+BRANCH=$gitBranch
 
 # input parameters
 CHECKOUT_DIRS=( "$@" )

--- a/modules/persist-data-ef-core/setup/setup.sh
+++ b/modules/persist-data-ef-core/setup/setup.sh
@@ -71,10 +71,9 @@ echo "Using Azure resource group ${bold}${cyan}$resourceGroupName${plain}${white
 declare instanceId=$(($RANDOM * $RANDOM))
 
 # Variables
-declare gitUrl=https://github.com/MicrosoftDocs/mslearn-aspnet-core
-declare gitBranch=master
+declare -x gitBranch=live
 declare gitDirectoriesToClone="modules/persist-data-ef-core/setup/ modules/persist-data-ef-core/src/"
-declare gitPathToCloneScript=https://raw.githubusercontent.com/MicrosoftDocs/mslearn-aspnet-core/master/infrastructure/scripts/sparsecheckout.sh
+declare gitPathToCloneScript=https://raw.githubusercontent.com/MicrosoftDocs/mslearn-aspnet-core/$gitBranch/infrastructure/scripts/sparsecheckout.sh
 
 declare srcWorkingDirectory=~/contoso-pets/src
 declare setupWorkingDirectory=~/contoso-pets/setup
@@ -175,8 +174,6 @@ downloadAndBuild() {
 # Write variables script
 writeVariablesScript() {
     text="#!/bin/bash${newline}"
-    text+="declare gitUrl=$gitUrl${newline}"
-    text+="declare gitBranch=$gitBranch${newline}"
     text+="declare srcWorkingDirectory=$srcWorkingDirectory${newline}"
     text+="declare setupWorkingDirectory=$setupWorkingDirectory${newline}"
     text+="declare gitRepoWorkingDirectory=$gitRepoWorkingDirectory${newline}"


### PR DESCRIPTION
This PR does two things:

1. Adds *~/.dotnet/tools* to the PATH variable on the current instance of the shell as well as *variables.sh*. This enables us to use .NET Core Global Tools with the --global parameter and call them with `dotnet <command>`.
2. Adds *variables.sh* to *.bashrc*. This means that when the student navigates away from Learn (or times out) the variable script will run automatically when they reconnect. I will submit an accompanying PR to Ashley/Diane to deprecate our "if you are disconnected" language after we merge this to live.

This script has been fully tested against the production persist-data-ef-core module.