### PR TITLE
ms-vscode.csharp to ms-dotnettools.csharp

### DIFF
--- a/modules/create-razor-pages-aspnet-core/src/.vscode/extensions.json
+++ b/modules/create-razor-pages-aspnet-core/src/.vscode/extensions.json
@@ -1,5 +1,5 @@
 {
     "recommendations": [
-        "ms-vscode.csharp"
+        "ms-dotnettools.csharp"
     ]
 }

--- a/modules/persist-data-ef-core/src/.vscode/extensions.json
+++ b/modules/persist-data-ef-core/src/.vscode/extensions.json
@@ -1,5 +1,5 @@
 {
     "recommendations": [
-        "ms-vscode.csharp"
+        "ms-dotnettools.csharp"
     ]
 }

--- a/modules/secure-aspnet-core-identity/src/.vscode/extensions.json
+++ b/modules/secure-aspnet-core-identity/src/.vscode/extensions.json
@@ -1,5 +1,5 @@
 {
     "recommendations": [
-        "ms-vscode.csharp"
+        "ms-dotnettools.csharp"
     ]
 }


### PR DESCRIPTION
C# extension has changed its name from "ms-vscode.csharp" to "ms-dotnettools.csharp", this means all extensions depending on it needs to be updated and all repositories with extension.json containing
```json
"recommendations": [
    "ms-vscode.csharp"
 ]
```
or you get errors like

![image](https://user-images.githubusercontent.com/1647294/76144809-2c18e500-6084-11ea-80ab-f365de742c99.png)
