### PR TITLE
Revert web API module's setup script to .NET Core 3.1

### DIFF
--- a/modules/build-web-api-aspnet-core/setup/setup.sh
+++ b/modules/build-web-api-aspnet-core/setup/setup.sh
@@ -13,12 +13,12 @@
 # Module name
 declare moduleName="build-web-api-aspnet-core"
 # dotnet SDK version
-declare -x dotnetSdkVersion="5.0.103"
+declare -x dotnetSdkVersion="3.1.406"
 
 # Any other declarations we need
-declare -x gitBranch="live"
+declare -x gitBranch="scottaddie/revert-to-3.1"
 declare initScript=https://raw.githubusercontent.com/MicrosoftDocs/mslearn-aspnet-core/$gitBranch/infrastructure/scripts/initenvironment.sh
-declare dotnetBotGreeting="I have configured .NET SDK $dotnetSdkVersion. Have fun!"
+declare dotnetBotGreeting="I have configured .NET Core SDK $dotnetSdkVersion. Have fun!"
 declare suppressAzureResources=true
 
 # Grab and run initenvironment.sh

--- a/modules/build-web-api-aspnet-core/setup/setup.sh
+++ b/modules/build-web-api-aspnet-core/setup/setup.sh
@@ -16,7 +16,7 @@ declare moduleName="build-web-api-aspnet-core"
 declare -x dotnetSdkVersion="3.1.406"
 
 # Any other declarations we need
-declare -x gitBranch="scottaddie/revert-to-3.1"
+declare -x gitBranch="live"
 declare initScript=https://raw.githubusercontent.com/MicrosoftDocs/mslearn-aspnet-core/$gitBranch/infrastructure/scripts/initenvironment.sh
 declare dotnetBotGreeting="I have configured .NET Core SDK $dotnetSdkVersion. Have fun!"
 declare suppressAzureResources=true


### PR DESCRIPTION
Fixes https://github.com/MicrosoftDocs/mslearn-aspnet-core/issues/72

This PR updates the web API module's setup script to use .NET Core 3.1 instead of .NET 5.0. The Cloud Shell can't handle .NET 5.0 right now.