### PR TITLE
Remove deprecated enable-soft-delete option from Az CLI command

### DIFF
--- a/infrastructure/scripts/provisioning/keyvault.sh
+++ b/infrastructure/scripts/provisioning/keyvault.sh
@@ -3,7 +3,6 @@
     set -x
     az keyvault create \
         --name $keyVaultName \
-        --enable-soft-delete \
         --output none
 )
 (


### PR DESCRIPTION
In the ASP.NET Core Identity module, the following warning is displaying when provisioning the Azure Key Vault resource:

![image](https://user-images.githubusercontent.com/10702007/108433462-a5fd9c00-720b-11eb-8466-074911857d34.png)

This PR removes the deprecated flag from the Azure CLI command.