### PR TITLE
Update setup.sh

### DIFF
--- a/modules/microservices-logging-aspnet-core/setup/setup.sh
+++ b/modules/microservices-logging-aspnet-core/setup/setup.sh
@@ -48,7 +48,7 @@ else
     code .
 
     # Run eshop-learn quickstart to deploy to AKS
-    $editorHomeLocation/deploy/k8s/quickstart.sh --resource-group eshop-learn-rg --location westus
+    $editorHomeLocation/deploy/k8s/quickstart.sh --resource-group eshop-learn-rg --location centralus
 
     # Create ACR resource
     $editorHomeLocation/deploy/k8s/create-acr.sh


### PR DESCRIPTION
ERROR: (BadRequest) The VM size of AgentPoolProfile:nodepool1 is not allowed in your subscription in location 'westus'. The available VM sizes are 'standard_d11,standard_d12,standard_d13,standard_d14,standard_d16_v5,standard_d16d_v5,standard_d16ds_v5,standard_d16s_v5,standard_d2,standard_d2_v5,standard_d2d_v5,standard_d2ds_v5,standard_d2s_v5,standard_d3,standard_d32_v5,standard_d32d_v5,standard_d32ds_v5,standard_d32s_v5,standard_d4,standard_d48_v5,standard_d48d_v5,standard_d48ds_v5,standard_d48s_v5,standard_d4_v5,standard_d4d_v5,standard_d4ds_v5,standard_d4s_v5,standard_d64_v5,standard_d64d_v5,standard_d64ds_v5,standard_d64s_v5,standard_d8_v5,standard_d8d_v5,standard_d8ds_v5,standard_d8s_v5,standard_d96_v5,standard_d96d_v5,standard_d96ds_v5,standard_d96s_v5,standard_dc16ads_v5,standard_dc16as_v5,standard_dc2ads_v5,standard_dc2as_v5,standard_dc2s_v2,standard_dc32ads_v5,standard_dc32as_v5,standard_dc48ads_v5,standard_dc48as_v5,standard_dc4ads_v5,standard_dc4as_v5,standard_dc4s_v2,standard_dc64ads_v5,standard_dc64as_v5,standard_dc8_v2,standard_dc8ads_v5,standard_dc8as_v5,standard_dc96ads_v5,standard_dc96as_v5,standard_e104i_v5,standard_e104id_v5,standard_e104ids_v5,standard_e104is_v5,standard_e16-4ds_v5,standard_e16-4s_v5,standard_e16-8ds_v5,standard_e16-8s_v5,standard_e16_v5,standard_e16d_v5,standard_e16ds_v5,standard_e16s_v5,standard_e20_v5,standard_e20d_v5,standard_e20ds_v5,standard_e20s_v5,standard_e2_v5,standard_e2d_v5,standard_e2ds_v5,standard_e2s_v5,standard_e32-16ds_v5,standard_e32-16s_v5,standard_e32-8ds_v5,standard_e32-8s_v5,standard_e32_v5,standard_e32d_v5,standard_e32ds_v5,standard_e32s_v5,standard_e4-2ds_v5,standard_e4-2s_v5,standard_e48_v5,standard_e48d_v5,standard_e48ds_v5,standard_e48s_v5,standard_e4_v5,standard_e4d_v5,standard_e4ds_v5,standard_e4s_v5,standard_e64-16ds_v5,standard_e64-16s_v5,standard_e64-32ds_v5,standard_e64-32s_v5,standard_e64_v5,standard_e64d_v5,standard_e64ds_v5,standard_e64s_v5,standard_e8-2ds_v5,standard_e8-2s_v5,standard_e8-4ds_v5,standard_e8-4s_v5,standard_e8_v5,standard_e8d_v5,standard_e8ds_v5,standard_e8s_v5,standard_e96-24ds_v5,standard_e96-24s_v5,standard_e96-48ds_v5,standard_e96-48s_v5,standard_e96_v5,standard_e96d_v5,standard_e96ds_v5,standard_e96s_v5,standard_ec16ads_v5,standard_ec16as_v5,standard_ec20ads_v5,standard_ec20as_v5,standard_ec2ads_v5,standard_ec2as_v5,standard_ec32ads_v5,standard_ec32as_v5,standard_ec48ads_v5,standard_ec48as_v5,standard_ec4ads_v5,standard_ec4as_v5,standard_ec64ads_v5,standard_ec64as_v5,standard_ec8ads_v5,standard_ec8as_v5,standard_ec96ads_v5,standard_ec96as_v5,standard_ec96iads_v5,standard_ec96ias_v5,standard_m208ms_v2,standard_m208s_v2,standard_m416-208ms_v2,standard_m416-208s_v2,standard_m416ms_v2,standard_m416s_v2' For more details, please visit https://aka.ms/cpu-quota
Code: BadRequest
Message: The VM size of AgentPoolProfile:nodepool1 is not allowed in your subscription in location 'westus'. The available VM sizes are 'standard_d11,standard_d12,standard_d13,standard_d14,standard_d16_v5,standard_d16d_v5,standard_d16ds_v5,standard_d16s_v5,standard_d2,standard_d2_v5,standard_d2d_v5,standard_d2ds_v5,standard_d2s_v5,standard_d3,standard_d32_v5,standard_d32d_v5,standard_d32ds_v5,standard_d32s_v5,standard_d4,standard_d48_v5,standard_d48d_v5,standard_d48ds_v5,standard_d48s_v5,standard_d4_v5,standard_d4d_v5,standard_d4ds_v5,standard_d4s_v5,standard_d64_v5,standard_d64d_v5,standard_d64ds_v5,standard_d64s_v5,standard_d8_v5,standard_d8d_v5,standard_d8ds_v5,standard_d8s_v5,standard_d96_v5,standard_d96d_v5,standard_d96ds_v5,standard_d96s_v5,standard_dc16ads_v5,standard_dc16as_v5,standard_dc2ads_v5,standard_dc2as_v5,standard_dc2s_v2,standard_dc32ads_v5,standard_dc32as_v5,standard_dc48ads_v5,standard_dc48as_v5,standard_dc4ads_v5,standard_dc4as_v5,standard_dc4s_v2,standard_dc64ads_v5,standard_dc64as_v5,standard_dc8_v2,standard_dc8ads_v5,standard_dc8as_v5,standard_dc96ads_v5,standard_dc96as_v5,standard_e104i_v5,standard_e104id_v5,standard_e104ids_v5,standard_e104is_v5,standard_e16-4ds_v5,standard_e16-4s_v5,standard_e16-8ds_v5,standard_e16-8s_v5,standard_e16_v5,standard_e16d_v5,standard_e16ds_v5,standard_e16s_v5,standard_e20_v5,standard_e20d_v5,standard_e20ds_v5,standard_e20s_v5,standard_e2_v5,standard_e2d_v5,standard_e2ds_v5,standard_e2s_v5,standard_e32-16ds_v5,standard_e32-16s_v5,standard_e32-8ds_v5,standard_e32-8s_v5,standard_e32_v5,standard_e32d_v5,standard_e32ds_v5,standard_e32s_v5,standard_e4-2ds_v5,standard_e4-2s_v5,standard_e48_v5,standard_e48d_v5,standard_e48ds_v5,standard_e48s_v5,standard_e4_v5,standard_e4d_v5,standard_e4ds_v5,standard_e4s_v5,standard_e64-16ds_v5,standard_e64-16s_v5,standard_e64-32ds_v5,standard_e64-32s_v5,standard_e64_v5,standard_e64d_v5,standard_e64ds_v5,standard_e64s_v5,standard_e8-2ds_v5,standard_e8-2s_v5,standard_e8-4ds_v5,standard_e8-4s_v5,standard_e8_v5,standard_e8d_v5,standard_e8ds_v5,standard_e8s_v5,standard_e96-24ds_v5,standard_e96-24s_v5,standard_e96-48ds_v5,standard_e96-48s_v5,standard_e96_v5,standard_e96d_v5,standard_e96ds_v5,standard_e96s_v5,standard_ec16ads_v5,standard_ec16as_v5,standard_ec20ads_v5,standard_ec20as_v5,standard_ec2ads_v5,standard_ec2as_v5,standard_ec32ads_v5,standard_ec32as_v5,standard_ec48ads_v5,standard_ec48as_v5,standard_ec4ads_v5,standard_ec4as_v5,standard_ec64ads_v5,standard_ec64as_v5,standard_ec8ads_v5,standard_ec8as_v5,standard_ec96ads_v5,standard_ec96as_v5,standard_ec96iads_v5,standard_ec96ias_v5,standard_m208ms_v2,standard_m208s_v2,standard_m416-208ms_v2,standard_m416-208s_v2,standard_m416ms_v2,standard_m416s_v2' For more details, please visit https://aka.ms/cpu-quota