### PR TITLE
Vnbaaij patch 1

### DIFF
--- a/infrastructure/scripts/initenvironment.sh
+++ b/infrastructure/scripts/initenvironment.sh
@@ -67,7 +67,7 @@ setAzureCliDefaults() {
         set -x
         az configure --defaults \
             group=$resourceGroupName \
-            location=$defaultLocation
+            location=$defaultRegion
     )
 }
 resetAzureCliDefaults() {

--- a/infrastructure/scripts/initenvironment.sh
+++ b/infrastructure/scripts/initenvironment.sh
@@ -22,7 +22,11 @@ declare srcWorkingDirectory=$rootLocation/aspnet-learn/src
 declare setupWorkingDirectory=$rootLocation/aspnet-learn/setup
 declare subscriptionId=$(az account show --query id --output tsv)
 declare resourceGroupName=""
-declare defaultLocation="centralus"
+if ! [ $defaultRegion ]
+then
+    declare defaultRegion="centralus"
+fi
+
 
 # AppService Declarations
 declare appServicePlan=appservice$instanceId

--- a/modules/microservices-logging-aspnet-core/setup/setup.sh
+++ b/modules/microservices-logging-aspnet-core/setup/setup.sh
@@ -18,6 +18,10 @@ declare -x dotnetSdkVersion="3.1.403"
 declare moduleName="microservices-logging-aspnet-core"
 
 # Any other declarations we need
+if ! [ $defaultRegion ]
+then
+    declare defaultRegion=centralus
+fi
 declare -x gitBranch="live"
 declare initScript=https://raw.githubusercontent.com/MicrosoftDocs/mslearn-aspnet-core/$gitBranch/infrastructure/scripts/initenvironment.sh
 declare suppressAzureResources=true
@@ -48,7 +52,7 @@ else
     code .
 
     # Run eshop-learn quickstart to deploy to AKS
-    $editorHomeLocation/deploy/k8s/quickstart.sh --resource-group eshop-learn-rg --location centralus
+    $editorHomeLocation/deploy/k8s/quickstart.sh --resource-group eshop-learn-rg --location $defaultRegion
 
     # Create ACR resource
     $editorHomeLocation/deploy/k8s/create-acr.sh


### PR DESCRIPTION
Change `defaultLocation` to `defaultRegion` in setup and initenvironment and check its existence as a environment variable. That way you can set it before calling the setup script and have all resources deployed to the region of your liking.

I did this for the `microservices-logging...` exercise. If this PR is accepted, I can do the same for the other microservices exercises as well.